### PR TITLE
Fix for Windows compatibility

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.15.0
+version = 0.19.0
 profile = default
 break-cases = all
 break-fun-decl = fit-or-vertical

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.5)
+(lang dune 2.9)
 
 (name elastic-apm)
 
@@ -20,8 +20,8 @@
  (depends
   (ocaml (>= 4.08.0))
   (cohttp-lwt-unix (>= 2.5.4))
-  (dune (>= 2.5.0))
-  (dune-build-info (>= 2.5.0))
+  (dune (>= 2.9.1))
+  (dune-build-info (>= 2.9.1))
   (ppx_deriving (>= 4.5))
   (ppx_deriving_yojson (>= 3.5.3))
   (ptime (>= 0.8.5))

--- a/elastic-apm.opam
+++ b/elastic-apm.opam
@@ -15,17 +15,18 @@ bug-reports: "https://github.com/elastic/apm-agent-ocaml/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "cohttp-lwt-unix" {>= "2.5.4"}
-  "dune" {>= "2.5.0"}
-  "dune-build-info" {>= "2.5.0"}
+  "dune" {>= "2.9" & >= "2.9.1"}
+  "dune-build-info" {>= "2.9.1"}
   "ppx_deriving" {>= "4.5"}
   "ppx_deriving_yojson" {>= "3.5.3"}
   "ptime" {>= "0.8.5"}
   "uri" {>= "3.0.0"}
   "uuidm" {>= "0.9.7"}
   "yojson" {>= "1.6.0"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -33,9 +34,11 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/elastic/apm-agent-ocaml.git"

--- a/src/apm.ml
+++ b/src/apm.ml
@@ -22,7 +22,8 @@ module Sender = struct
       Log.warn (fun m ->
           m "APM server response %d: %s"
             (Cohttp.Code.code_of_status response.status)
-            body)
+            body
+      )
 
   let sleep () = Lwt_unix.sleep 5.0
   let rec run_forever () =

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,11 @@
  (public_name elastic-apm)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.std))
- (libraries uri yojson ppx_deriving_yojson.runtime uuidm cohttp-lwt-unix
-   mtime.clock.os dune-build-info))
+ (libraries
+  uri
+  yojson
+  ppx_deriving_yojson.runtime
+  uuidm
+  cohttp-lwt-unix
+  mtime.clock.os
+  dune-build-info))

--- a/src/metadata.ml
+++ b/src/metadata.ml
@@ -10,7 +10,13 @@ let current_process =
   let argv = Sys.argv |> Array.to_list in
   let title = Sys.executable_name in
   let pid = Unix.getpid () in
-  let ppid = Unix.getppid () in
+  let ppid =
+    if Sys.win32 then
+      (* Unix.getppid is not available on Windows *)
+      pid
+    else
+      Unix.getppid ()
+  in
   make_process ~pid ~title ~ppid ~argv ()
 
 type system = {


### PR DESCRIPTION
This PR does three things:
- On Windows, use the PID in place of `Unix.getppid` where that call is not available
- Bump to the latest `dune` so we generate correct opam metadata
- Bump to the latest `ocamlformat`