### PR TITLE
Align with apm spec

### DIFF
--- a/core/metadata.ml
+++ b/core/metadata.ml
@@ -149,7 +149,7 @@ module Service = struct
     name : string;
     version : string option; [@yojson.option]
     environment : string option; [@yojson.option]
-    agent : Agent.t option; [@yojson.option]
+    agent : Agent.t;
     framework : Framework.t option; [@yojson.option]
     language : Language.t option; [@yojson.option]
     runtime : Runtime.t option; [@yojson.option]
@@ -162,7 +162,7 @@ module Service = struct
       name;
       version;
       environment;
-      agent = Some Agent.t;
+      agent = Agent.t;
       framework;
       language = Some Language.t;
       runtime = Some Runtime.t;
@@ -196,14 +196,10 @@ module User = struct
 end
 
 type t = {
-  process : Process.t option; [@yojson.option]
-  system : System.t option; [@yojson.option]
-  agent : Agent.t option; [@yojson.option]
-  framework : Framework.t option; [@yojson.option]
-  language : Language.t option; [@yojson.option]
-  runtime : Runtime.t option; [@yojson.option]
   cloud : Cloud.t option; [@yojson.option]
+  process : Process.t option; [@yojson.option]
   service : Service.t;
+  system : System.t option; [@yojson.option]
   user : User.t option; [@yojson.option]
 }
 [@@deriving yojson_of]
@@ -211,19 +207,8 @@ type t = {
 let make
     ?(process = Lazy.force Process.default)
     ?(system = System.make ())
-    ?framework
     ?cloud
     ?user
     service =
-  {
-    process = Some process;
-    system = Some system;
-    agent = Some Agent.t;
-    framework;
-    language = Some Language.t;
-    runtime = Some Runtime.t;
-    cloud;
-    service;
-    user;
-  }
+  { process = Some process; system = Some system; cloud; service; user }
 ;;

--- a/core/metadata.mli
+++ b/core/metadata.mli
@@ -86,7 +86,6 @@ type t [@@deriving yojson_of]
 val make :
   ?process:Process.t ->
   ?system:System.t ->
-  ?framework:Framework.t ->
   ?cloud:Cloud.t ->
   ?user:User.t ->
   Service.t ->

--- a/example/1-hello-opium/dune
+++ b/example/1-hello-opium/dune
@@ -4,4 +4,3 @@
  (libraries base elastic-apm-opium-middleware opium logs.fmt fmt.tty)
  (preprocess
   (pps lwt_ppx ppx_yojson_conv)))
-

--- a/example/1-hello-opium/hello.ml
+++ b/example/1-hello-opium/hello.ml
@@ -17,10 +17,9 @@ let reverse_handler req =
 
 let init () =
   Fmt_tty.setup_std_outputs ();
-  Logs.set_level (Some Debug);
+  Logs.set_level (Some Info);
   Logs.set_reporter (Logs_fmt.reporter ());
-  let service = Elastic_apm.Metadata.Service.make "opium-elastic-apm-demo" in
-  Elastic_apm_opium_middleware.Apm.Init.setup_reporter service
+  Elastic_apm_opium_middleware.Apm.Init.setup_reporter "opium-elastic-apm-demo"
 ;;
 
 let () =

--- a/example/2-database-ocaml/hello.ml
+++ b/example/2-database-ocaml/hello.ml
@@ -65,10 +65,8 @@ let init () =
   Fmt_tty.setup_std_outputs ();
   Logs.set_reporter (Logs_fmt.reporter ());
   Logs.set_level (Some Info);
-  let service =
-    Elastic_apm.Metadata.Service.make "elastic-apm-opium-example-database"
-  in
-  Elastic_apm_opium_middleware.Apm.Init.setup_reporter service
+  Elastic_apm_opium_middleware.Apm.Init.setup_reporter
+    "elastic-apm-opium-example-database"
 ;;
 
 let () =

--- a/example/3-polyglot-services/ocaml/hello.ml
+++ b/example/3-polyglot-services/ocaml/hello.ml
@@ -52,10 +52,8 @@ let init () =
   Fmt_tty.setup_std_outputs ();
   Logs.set_reporter (Logs_fmt.reporter ());
   Logs.set_level (Some Debug);
-  let service =
-    Elastic_apm.Metadata.Service.make "elastic-apm-opium-example-polyglot"
-  in
-  Elastic_apm_opium_middleware.Apm.Init.setup_reporter service
+  Elastic_apm_opium_middleware.Apm.Init.setup_reporter
+    "elastic-apm-opium-example-polyglot"
 ;;
 
 let () =

--- a/lwt_client/client.ml
+++ b/lwt_client/client.ml
@@ -151,9 +151,9 @@ let with_span context ~kind name f =
   (report_exn f context) [%lwt.finally Lwt.return (Span.close context)]
 ;;
 
-let init_reporter ?framework host service =
+let init_reporter host service =
   let reporter =
-    let metadata = Elastic_apm.Metadata.make ?framework service in
+    let metadata = Elastic_apm.Metadata.make service in
     Elastic_apm_lwt_reporter.Reporter.create host metadata
   in
   set_reporter (Some reporter)

--- a/lwt_client/client.mli
+++ b/lwt_client/client.mli
@@ -10,7 +10,6 @@ val make_context' :
   context
 
 val init_reporter :
-  ?framework:Elastic_apm.Metadata.Framework.t ->
   Elastic_apm_lwt_reporter.Reporter.Host.t ->
   Elastic_apm.Metadata.Service.t ->
   unit

--- a/opium_middleware/apm.ml
+++ b/opium_middleware/apm.ml
@@ -16,8 +16,7 @@ module Init = struct
       )
     | Some host ->
       let reporter =
-        let framework = Elastic_apm.Metadata.Framework.make "opium" in
-        let metadata = Elastic_apm.Metadata.make ~framework service in
+        let metadata = Elastic_apm.Metadata.make service in
         Elastic_apm_lwt_reporter.Reporter.create host metadata
       in
       Elastic_apm_lwt_client.Client.set_reporter (Some reporter)

--- a/opium_middleware/apm.ml
+++ b/opium_middleware/apm.ml
@@ -1,5 +1,11 @@
 module Init = struct
-  let setup_reporter ?host service =
+  let setup_reporter ?host ?version ?environment ?node service_name =
+    let open Elastic_apm in
+    let service =
+      Metadata.Service.make ?version ?environment ?node
+        ~framework:(Metadata.Framework.make "Opium")
+        service_name
+    in
     let module Reporter = Elastic_apm_lwt_reporter.Reporter in
     let host =
       match host with

--- a/opium_middleware/apm.mli
+++ b/opium_middleware/apm.mli
@@ -1,7 +1,10 @@
 module Init : sig
   val setup_reporter :
     ?host:Elastic_apm_lwt_reporter.Reporter.Host.t ->
-    Elastic_apm.Metadata.Service.t ->
+    ?version:string ->
+    ?environment:string ->
+    ?node:string ->
+    string ->
     unit
 end
 

--- a/test/json_serialization.ml
+++ b/test/json_serialization.ml
@@ -189,7 +189,7 @@ let%expect_test "metadata - user" =
 ;;
 
 let metadata =
-  Metadata.make ~process ~system ~framework ~cloud ~user
+  Metadata.make ~process ~system ~cloud ~user
     (Metadata.Service.make "testservice")
 ;;
 
@@ -198,22 +198,6 @@ let%expect_test "metadata" =
   [%expect
     {|
     {
-      "process": {
-        "pid": 2,
-        "title": "process.exe",
-        "ppid": 1,
-        "argv": [ "hello", "world" ]
-      },
-      "system": {
-        "architecture": "256bit",
-        "hostname": "testhost",
-        "platform": "testplatform",
-        "container": { "id": "hiimacontainer" }
-      },
-      "agent": { "name": "OCaml", "version": "n/a" },
-      "framework": { "name": "frame", "version": "beta" },
-      "language": { "name": "OCaml", "version": "4.13.1" },
-      "runtime": { "name": "OCaml", "version": "4.13.1" },
       "cloud": {
         "provider": "name",
         "region": "reg",
@@ -223,11 +207,23 @@ let%expect_test "metadata" =
         "account": { "id": "012", "name": "abc" },
         "project": { "id": "012", "name": "abc" }
       },
+      "process": {
+        "pid": 2,
+        "title": "process.exe",
+        "ppid": 1,
+        "argv": [ "hello", "world" ]
+      },
       "service": {
         "name": "testservice",
         "agent": { "name": "OCaml", "version": "n/a" },
         "language": { "name": "OCaml", "version": "4.13.1" },
         "runtime": { "name": "OCaml", "version": "4.13.1" }
+      },
+      "system": {
+        "architecture": "256bit",
+        "hostname": "testhost",
+        "platform": "testplatform",
+        "container": { "id": "hiimacontainer" }
       },
       "user": {
         "username": "admin",
@@ -361,22 +357,6 @@ let%expect_test "serialize request payloads" =
     {|
     {
       "metadata": {
-        "process": {
-          "pid": 2,
-          "title": "process.exe",
-          "ppid": 1,
-          "argv": [ "hello", "world" ]
-        },
-        "system": {
-          "architecture": "256bit",
-          "hostname": "testhost",
-          "platform": "testplatform",
-          "container": { "id": "hiimacontainer" }
-        },
-        "agent": { "name": "OCaml", "version": "n/a" },
-        "framework": { "name": "frame", "version": "beta" },
-        "language": { "name": "OCaml", "version": "4.13.1" },
-        "runtime": { "name": "OCaml", "version": "4.13.1" },
         "cloud": {
           "provider": "name",
           "region": "reg",
@@ -386,11 +366,23 @@ let%expect_test "serialize request payloads" =
           "account": { "id": "012", "name": "abc" },
           "project": { "id": "012", "name": "abc" }
         },
+        "process": {
+          "pid": 2,
+          "title": "process.exe",
+          "ppid": 1,
+          "argv": [ "hello", "world" ]
+        },
         "service": {
           "name": "testservice",
           "agent": { "name": "OCaml", "version": "n/a" },
           "language": { "name": "OCaml", "version": "4.13.1" },
           "runtime": { "name": "OCaml", "version": "4.13.1" }
+        },
+        "system": {
+          "architecture": "256bit",
+          "hostname": "testhost",
+          "platform": "testplatform",
+          "container": { "id": "hiimacontainer" }
         },
         "user": {
           "username": "admin",
@@ -438,7 +430,7 @@ let%expect_test "serialize request payloads" =
             },
             {
               "filename": "test/json_serialization.ml",
-              "lineno": 402,
+              "lineno": 394,
               "function": "Apm_agent_tests__Json_serialization.(fun)",
               "colno": 6
             }

--- a/test/logs_reporter_output.ml
+++ b/test/logs_reporter_output.ml
@@ -32,7 +32,7 @@ let%expect_test "logs reporter - default logs src" =
   Elastic_apm_logs_reporter.Reporter.push reporter (Transaction transaction);
   [%expect
     {|
-    inline_test_runner_apm_agent_tests.exe: [INFO] {"metadata":{"process":{"pid":1,"title":"testprocess","argv":[]},"system":{"architecture":"testarch","hostname":"testhost","platform":"testplatform"},"agent":{"name":"OCaml","version":"n/a"},"language":{"name":"OCaml","version":"4.13.1"},"runtime":{"name":"OCaml","version":"4.13.1"},"service":{"name":"testservice","agent":{"name":"OCaml","version":"n/a"},"language":{"name":"OCaml","version":"4.13.1"},"runtime":{"name":"OCaml","version":"4.13.1"}}}}
+    inline_test_runner_apm_agent_tests.exe: [INFO] {"metadata":{"process":{"pid":1,"title":"testprocess","argv":[]},"service":{"name":"testservice","agent":{"name":"OCaml","version":"n/a"},"language":{"name":"OCaml","version":"4.13.1"},"runtime":{"name":"OCaml","version":"4.13.1"}},"system":{"architecture":"testarch","hostname":"testhost","platform":"testplatform"}}}
     inline_test_runner_apm_agent_tests.exe: [INFO] {"transaction":{"timestamp":15768000000000000,"duration":80.0,"id":"3e466abbf8b38218","span_count":{"started":1},"trace_id":"5e00cc610bf958d233ad4932f4e954cc","type":"request","name":"testtransaction"}}|}];
   (* No metadata on following log output *)
   Elastic_apm_logs_reporter.Reporter.push reporter (Transaction transaction);
@@ -48,7 +48,7 @@ let%expect_test "logs reporter - custom logs src" =
   Elastic_apm_logs_reporter.Reporter.push reporter (Transaction transaction);
   [%expect
     {|
-    inline_test_runner_apm_agent_tests.exe: [INFO] {"metadata":{"process":{"pid":1,"title":"testprocess","argv":[]},"system":{"architecture":"testarch","hostname":"testhost","platform":"testplatform"},"agent":{"name":"OCaml","version":"n/a"},"language":{"name":"OCaml","version":"4.13.1"},"runtime":{"name":"OCaml","version":"4.13.1"},"service":{"name":"testservice","agent":{"name":"OCaml","version":"n/a"},"language":{"name":"OCaml","version":"4.13.1"},"runtime":{"name":"OCaml","version":"4.13.1"}}}}
+    inline_test_runner_apm_agent_tests.exe: [INFO] {"metadata":{"process":{"pid":1,"title":"testprocess","argv":[]},"service":{"name":"testservice","agent":{"name":"OCaml","version":"n/a"},"language":{"name":"OCaml","version":"4.13.1"},"runtime":{"name":"OCaml","version":"4.13.1"}},"system":{"architecture":"testarch","hostname":"testhost","platform":"testplatform"}}}
     inline_test_runner_apm_agent_tests.exe: [INFO] {"transaction":{"timestamp":15768000000000000,"duration":80.0,"id":"3e466abbf8b38218","span_count":{"started":1},"trace_id":"5e00cc610bf958d233ad4932f4e954cc","type":"request","name":"testtransaction"}} |}];
   (* No metadata on following log output *)
   Elastic_apm_logs_reporter.Reporter.push reporter (Transaction transaction);


### PR DESCRIPTION
* Agent is mandatory in Service object
* Language, Runtime and framework only need to be part of the service object, and not the root level metadata object
* Moved the service creation to opium middleware so it can populate the framework object with the correct names.