### PR TITLE
Only depend on `Rock` for the opium middleware

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -52,6 +52,7 @@
   (ocaml
    (>= 4.12.0))
   lwt
+  lwt_ppx
   cohttp-lwt-unix
   (elastic-apm
    (= :version))
@@ -74,7 +75,9 @@
  (depends
   (ocaml
    (>= 4.12.0))
-  opium
+  rock
   dune-build-info
+  rock
+  lwt_ppx
   (elastic-apm-lwt-client
    (= :version))))

--- a/elastic-apm-lwt-client.opam
+++ b/elastic-apm-lwt-client.opam
@@ -18,6 +18,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.12.0"}
   "lwt"
+  "lwt_ppx"
   "cohttp-lwt-unix"
   "elastic-apm" {= version}
   "elastic-apm-lwt-reporter" {= version}

--- a/elastic-apm-opium-middleware.opam
+++ b/elastic-apm-opium-middleware.opam
@@ -19,8 +19,10 @@ bug-reports: "https://github.com/elastic/apm-agent-ocaml/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.12.0"}
-  "opium"
+  "rock"
   "dune-build-info"
+  "rock"
+  "lwt_ppx"
   "elastic-apm-lwt-client" {= version}
   "odoc" {with-doc}
 ]

--- a/opium_middleware/apm.ml
+++ b/opium_middleware/apm.ml
@@ -10,7 +10,7 @@ module Init = struct
             (Build_info.V1.Statically_linked_library.version library)
       in
       Metadata.Service.make ?version ?environment ?node
-        ~framework:(Metadata.Framework.make ?version:framework_version "Opium")
+        ~framework:(Metadata.Framework.make ?version:framework_version "Rock")
         service_name
     in
     let module Reporter = Elastic_apm_lwt_reporter.Reporter in
@@ -61,7 +61,7 @@ end
 
 let m : Rock.Middleware.t =
   let filter handler (req : Rock.Request.t) =
-    let meth = Opium.Method.to_string req.meth in
+    let meth = Httpaf.Method.to_string req.meth in
     let path = req.target |> Uri.of_string |> Uri.path in
     let name = Fmt.str "%s %s" meth path in
     let parent_id =

--- a/opium_middleware/dune
+++ b/opium_middleware/dune
@@ -3,4 +3,4 @@
  (public_name elastic-apm-opium-middleware)
  (preprocess
   (pps lwt_ppx))
- (libraries elastic-apm-lwt-client opium dune-build-info))
+ (libraries elastic-apm-lwt-client rock dune-build-info))


### PR DESCRIPTION
The only module used from `opium` was `Method`. We can stick to just
depending on `Rock` if we use the to_string method from `Httpaf`.