### PR TITLE
Make logs less noisy for lwt reporter

### DIFF
--- a/lwt_reporter/lib/reporter.ml
+++ b/lwt_reporter/lib/reporter.ml
@@ -1,6 +1,8 @@
 open Lwt.Infix
 
-module Log = (val Logs.src_log (Logs.Src.create "elastic_apm.lwt_reporter"))
+let log_source = Logs.Src.create "elastic_apm.lwt_reporter"
+
+module Log = (val Logs.src_log log_source)
 
 module Host = struct
   type t = {

--- a/lwt_reporter/lib/reporter.mli
+++ b/lwt_reporter/lib/reporter.mli
@@ -1,5 +1,9 @@
 include Elastic_apm.Reporter_intf.S
 
+val log_source : Logs.Src.t
+(** The log source used for all logging within the lwt apm reporter. This can be
+    used to control the logging level filter for this library. *)
+
 module Host : sig
   type t
 


### PR DESCRIPTION
Also use a custom source which can be used to control the logs setup for
the lwt reporter